### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -8,6 +8,9 @@
 
 name: Java CI with Maven
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/marks-yag/retry/security/code-scanning/5](https://github.com/marks-yag/retry/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow does not inherit unnecessary permissions from the repository, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
